### PR TITLE
show wishlist for each group

### DIFF
--- a/app/views/wishlists/group_wishlists.html.erb
+++ b/app/views/wishlists/group_wishlists.html.erb
@@ -10,6 +10,7 @@
       <th scope="col">Name</th>
       <th scope="col">Price</th>
       <th scope="col">Icon</th>
+      <th scope="col">Creator</th>
       <th scope="col">Date</th>
       <th colspan="3" scope="col">Options</th>
     </tr>
@@ -28,6 +29,7 @@
         <% else %>
           <td> - </td>
         <% end%>  
+        <td><%= wishlist.author.username %></td>
         <td><%= wishlist.created_at.strftime("%b %d, %Y - %I:%M%p" ).downcase %></td>
         <td><%= link_to 'Show', wishlist %></td>
         <td><%= link_to 'Edit', edit_wishlist_path(wishlist) %></td>


### PR DESCRIPTION
6. When user opens the "Group transactions" page:
    1. A list of all transactions that belong to that group is displayed.
    2. The design of the page is similar to the "All my transactions". Besides the information that appears in All my transactions page, each transaction displays the **name of the author** of the transaction.